### PR TITLE
document and reorganize reference settings

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,50 +16,52 @@ kamon {
 
       # Max packet size for UDP metrics data sent to Datadog.
       max-packet-size = 1024 bytes
-
       measurement-formatter = "default"
-
       packetbuffer = "default"
+    }
 
+    #
+    # Settings relevant to the DatadogSpanReporter
+    #
+    trace {
+
+      # Default to agent URL (https://docs.datadoghq.com/api/?lang=python#tracing)
+      api-url = "http://localhost:8126/v0.4/traces"
+
+      # FQCN of the "kamon.datadog.KamonDataDogTranslator" implementation that will convert Kamon Spans into Datadog
+      # Spans, or "defult" to use the built-in translator.
+      translator = "default"
+
+      # HTTP client timeout settings:
+      #   - connect-timeout: how long to wait for an HTTP connection to establish before failing the request.
+      #   - read-timeout: how long to wait for a read IO operation to complete before failing the request.
+      #   - write-timeout: how long to wait for a write IO operation to complete before failing the request.
+      #
+      connect-timeout = 5 seconds
+      read-timeout = 5 seconds
+      write-timeout = 5 seconds
     }
 
     #
     # Settings relevant to the DatadogAPIReporter
     #
-    http {
+    api {
 
+      # API endpoint to which metrics time series data will be posted.
       api-url = "https://app.datadoghq.com/api/v1/series"
 
-
-      # Datadog API key to use to send metrics to datadog directly over HTTPS.
-      # If this is not set, metrics are sent as statsd packets over UDP to dogstatsd.
+      # Datadog API key to use to send metrics to Datadog directly over HTTPS. The API key will be combined with the
+      # API URL to get the complete endpoint use for posting time series to Datadog.
       api-key = ""
 
-      using-agent = false
-
+      # HTTP client timeout settings:
+      #   - connect-timeout: how long to wait for an HTTP connection to establish before failing the request.
+      #   - read-timeout: how long to wait for a read IO operation to complete before failing the request.
+      #   - write-timeout: how long to wait for a write IO operation to complete before failing the request.
+      #
       connect-timeout = 5 seconds
       read-timeout = 5 seconds
-      request-timeout = 5 seconds
-    }
-
-
-    #
-    # Settings relevant to the DatadogSpanReporter
-    #
-    trace.http {
-
-      # Default to agent URL (https://docs.datadoghq.com/api/?lang=python#tracing)
-      api-url = "http://localhost:8126/v0.4/traces"
-
-      api-key = ${kamon.datadog.http.api-key}
-
-      using-agent = true
-
-      connect-timeout = ${kamon.datadog.http.connect-timeout}
-      read-timeout = ${kamon.datadog.http.read-timeout}
-      request-timeout = ${kamon.datadog.http.request-timeout}
-
-      translator = "default"
+      write-timeout = 5 seconds
     }
 
 
@@ -84,8 +86,6 @@ kamon {
         excludes = []
       }
     }
-
-
   }
 
   modules {
@@ -96,19 +96,20 @@ kamon {
       factory = "kamon.datadog.DatadogAgentReporterFactory"
     }
 
+    datadog-trace-agent {
+      enabled = true
+      name = "DatadogSpanReporter"
+      description = "Datadog Span reporter"
+      factory = "kamon.datadog.DatadogSpanReporterFactory"
+    }
+
     datadog-api {
       enabled = false
       name = "DatadogHttp"
       description = "Datadog HTTP reporter"
       factory = "kamon.datadog.DatadogAPIReporterFactory"
     }
-
-    datadog-span-reporter {
-      enabled = true
-      name = "DatadogSpanReporter"
-      description = "Datadog Span reporter"
-      factory = "kamon.datadog.DatadogSpanReporterFactory"
-    }
   }
-
 }
+
+

--- a/src/main/scala/kamon/datadog/DatadogAPIReporter.scala
+++ b/src/main/scala/kamon/datadog/DatadogAPIReporter.scala
@@ -37,7 +37,7 @@ import scala.util.{ Failure, Success }
 class DatadogAPIReporterFactory extends ModuleFactory {
   override def create(settings: ModuleFactory.Settings): DatadogAPIReporter = {
     val config = DatadogAPIReporter.readConfiguration(settings.config)
-    new DatadogAPIReporter(config, new HttpClient(config.httpConfig))
+    new DatadogAPIReporter(config, new HttpClient(config.httpConfig, usingAgent = false))
   }
 }
 
@@ -59,7 +59,7 @@ class DatadogAPIReporter(@volatile private var configuration: Configuration, @vo
   override def reconfigure(config: Config): Unit = {
     val newConfiguration = readConfiguration(config)
     configuration = newConfiguration
-    httpClient = new HttpClient(configuration.httpConfig)
+    httpClient = new HttpClient(configuration.httpConfig, usingAgent = false)
   }
 
   override def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit = {
@@ -158,7 +158,7 @@ private object DatadogAPIReporter {
   def readConfiguration(config: Config): Configuration = {
     val datadogConfig = config.getConfig("kamon.datadog")
     Configuration(
-      datadogConfig.getConfig("http"),
+      datadogConfig.getConfig("api"),
       timeUnit = readTimeUnit(datadogConfig.getString("time-unit")),
       informationUnit = readInformationUnit(datadogConfig.getString("information-unit")),
       // Remove the "host" tag since it gets added to the datadog payload separately

--- a/src/main/scala/kamon/datadog/DatadogAgentReporter.scala
+++ b/src/main/scala/kamon/datadog/DatadogAgentReporter.scala
@@ -196,7 +196,8 @@ object DatadogAgentReporter {
       }
     }
 
-    private def fitsOnBuffer(data: String): Boolean = (buffer.length + data.length) <= maxPacketSizeInBytes
+    private def fitsOnBuffer(data: String): Boolean =
+      (buffer.length + data.length) <= maxPacketSizeInBytes
 
     private def flushToUDP(data: String): Unit = {
       val channel = DatagramChannel.open()

--- a/src/test/scala/kamon/datadog/DatadogAPIReporterSpec.scala
+++ b/src/test/scala/kamon/datadog/DatadogAPIReporterSpec.scala
@@ -21,8 +21,8 @@ class DatadogAPIReporterSpec extends AbstractHttpReporter with Matchers with Rec
 
     "sends counter metrics" in {
       val baseUrl = mockResponse("/test", new MockResponse().setStatus("HTTP/1.1 200 OK"))
-      applyConfig("kamon.datadog.http.api-url = \"" + baseUrl + "\"")
-      applyConfig("kamon.datadog.http.api-key = \"dummy\"")
+      applyConfig("kamon.datadog.api.api-url = \"" + baseUrl + "\"")
+      applyConfig("kamon.datadog.api.api-key = \"dummy\"")
 
       reporter.reconfigure(Kamon.config())
 

--- a/src/test/scala/kamon/datadog/DatadogSpanReporterSpec.scala
+++ b/src/test/scala/kamon/datadog/DatadogSpanReporterSpec.scala
@@ -1,6 +1,6 @@
 package kamon.datadog
 
-import java.time.{Duration, Instant}
+import java.time.{ Duration, Instant }
 import java.util.concurrent.TimeUnit
 
 import kamon.Kamon
@@ -59,30 +59,30 @@ trait TestData {
     "duration" -> JsNumber(duration.getSeconds * 1000000000 + duration.getNano),
     "name" -> "kamon.trace",
     "meta" -> Json.obj(
-      "env" -> "staging",
+      "env" -> "staging"
     ),
     "error" -> 0,
     "type" -> "custom",
     "start" -> JsNumber(from.getEpochNano),
     "metrics" -> JsObject(Seq(
-       "_sampling_priority_v1" -> JsNumber(1)
+      "_sampling_priority_v1" -> JsNumber(1)
     ))
   )
 
   val spanWithoutParentId = span.copy(parentId = Identifier.Empty)
   val jsonWithoutParentId = json - "parent_id"
 
-  val spanWithError = span.copy(tags = TagSet.of("error", true), hasError=true)
+  val spanWithError = span.copy(tags = TagSet.of("error", true), hasError = true)
 
   val jsonWithError = json ++ Json.obj(
     "meta" -> Json.obj(
       "error" -> "true",
-      "env" -> "staging",
+      "env" -> "staging"
     ),
     "error" -> 1
   )
 
-  val spanWithTags = span.copy(tags =
+  val spanWithTags = span.copy(metricTags =
     TagSet.from(
       Map(
         "string" -> "value",
@@ -104,7 +104,7 @@ trait TestData {
       "false" -> "false",
       "number" -> randomNumber.toString,
       "component" -> "custom.component",
-      "env" -> "staging",
+      "env" -> "staging"
     )
   )
 
@@ -115,7 +115,7 @@ trait TestData {
   val jsonWithMarks = json ++ Json.obj(
     "meta" -> Json.obj(
       "from" -> JsString(from.getEpochNano.toString),
-        "env" -> JsString("staging")
+      "env" -> JsString("staging")
     )
   )
 
@@ -144,8 +144,8 @@ trait TestData {
     "span with meta and marks" -> (Seq(spanWithTagsAndMarks), Json.arr(Json.arr(jsonWithTagsAndMarks))),
     "span with error" -> (Seq(spanWithError), Json.arr(Json.arr(jsonWithError))),
 
-    "multiple spans with same trace" -> (Seq(span, spanWithTags), Json.arr(Json.arr(json, jsonWithTags))),
-    // "multiple spans with two traces" -> (Seq(span, spanWithTags, otherTraceSpan, span), Json.arr(Json.arr(json, jsonWithTags, json), Json.arr(otherTraceJson)))
+    "multiple spans with same trace" -> (Seq(span, spanWithTags), Json.arr(Json.arr(json, jsonWithTags)))
+  // "multiple spans with two traces" -> (Seq(span, spanWithTags, otherTraceSpan, span), Json.arr(Json.arr(json, jsonWithTags, json), Json.arr(otherTraceJson)))
   )
 }
 
@@ -165,7 +165,7 @@ class DatadogSpanReporterSpec extends AbstractHttpReporter with Matchers with Re
 
         val baseUrl = mockResponse("/test", new MockResponse().setStatus("HTTP/1.1 200 OK").setBody("OK"))
 
-        applyConfig("kamon.datadog.trace.http.api-url = \"" + baseUrl + "\"")
+        applyConfig("kamon.datadog.trace.api-url = \"" + baseUrl + "\"")
         reporter.reconfigure(Kamon.config())
         reporter.reportSpans(spans)
         val request = server.takeRequest()
@@ -186,7 +186,7 @@ class DatadogSpanReporterSpec extends AbstractHttpReporter with Matchers with Re
 
     s"ignore error responses" in {
       val baseUrl = mockResponse("/test", new MockResponse().setStatus("HTTP/1.1 500 Internal Server Error"))
-      applyConfig("kamon.datadog.trace.http.api-url = \"" + baseUrl + "\"")
+      applyConfig("kamon.datadog.trace.api-url = \"" + baseUrl + "\"")
       reporter.reconfigure(Kamon.config())
       reporter.reportSpans(firstSpan)
       server.takeRequest()


### PR DESCRIPTION
Hey @Falmarri! I took your latest changes and made a few additional changes so that it sort of looks more like the rest of the modules. There is nothing really significant here, mostly a couple setting changes, comments on the reference conf and looking up the `component` tag from metricTags because that's where we usually add it.

Let me know what you think!